### PR TITLE
Adding support for running on Macs and using podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,14 @@ RUN wget https://github.com/mathjax/MathJax/archive/refs/tags/3.2.2.zip -O tmp.z
     rm -f tmp.zip
 
 # Pandoc
-RUN wget https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-1-amd64.deb -O tmp.deb && \
+RUN ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "amd64" ]; then \
+        wget https://github.com/jgm/pandoc/releases/download/3.8.2/pandoc-3.8.2-1-amd64.deb -O tmp.deb; \
+    elif [ "$ARCH" = "arm64" ]; then \
+        wget https://github.com/jgm/pandoc/releases/download/3.8.2/pandoc-3.8.2-1-arm64.deb -O tmp.deb; \
+    else \
+        echo "Unsupported architecture: $ARCH" && exit 1; \
+    fi && \
     dpkg -i tmp.deb && \
     rm -f tmp.deb
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 IMAGE_ROOT?=ghcr.io/csc-training
 IMAGE=slidefactory
-IMAGE_VERSION?=$(shell grep -m1 -oP '(?<=VERSION = ").+(?=")' slidefactory.py)
-
+IMAGE_VERSION=$(shell grep -m1 'VERSION = "' slidefactory.py | sed -E 's/.*VERSION = "(.*)".*/\1/')
+CONTAINER_CMD=$(shell command -v podman >/dev/null 2>&1 && echo podman || echo docker)
 
 build: Dockerfile slidefactory.py
-	docker build \
+	${CONTAINER_CMD} build \
+		--platform "linux/amd64,linux/arm64" \
 		--label "org.opencontainers.image.source=https://github.com/csc-training/slidefactory" \
 		--label "org.opencontainers.image.description=slidefactory" \
 		--build-arg VERSION=${IMAGE_VERSION} \
@@ -12,11 +13,11 @@ build: Dockerfile slidefactory.py
 		.
 
 push:
-	docker push ${IMAGE_ROOT}/${IMAGE}:${IMAGE_VERSION}
+	${CONTAINER_CMD} push ${IMAGE_ROOT}/${IMAGE}:${IMAGE_VERSION}
 
 singularity:
 	rm -f $(IMAGE).sif $(IMAGE).tar
-	docker save $(IMAGE_ROOT)/$(IMAGE):$(IMAGE_VERSION) -o $(IMAGE).tar
+	${CONTAINER_CMD} save $(IMAGE_ROOT)/$(IMAGE):$(IMAGE_VERSION) -o $(IMAGE).tar
 	singularity build $(IMAGE).sif docker-archive://$(IMAGE).tar
 	rm -f $(IMAGE).tar
 


### PR DESCRIPTION
Updates to Dockerfile
-  Updated pandoc version to latest since the previous release was not available.
- Allow creating container image that works on arm64 and amd64

Updates Makefile
- Using podman instead of docker if podman is installed.
- Using sed instead of grep with perl regex, since perl regex does not work on the version of grep that is installed on MacOS by default.
- Building image for arm64 and amd64 by default